### PR TITLE
chores(compose): created 2 distinct compose file for dev and prod env

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,61 @@
+---
+version: "3"
+
+
+services:
+
+  api:
+    container_name: ardiane_api
+    build: ./API-v2
+    depends_on:
+      - database
+    environment:
+      DATABASE_USER: "ardiane"
+      DATABASE_PASSWORD: "password"
+      DATABASE_DB: "ardiane"
+      DATABASE_HOST: "database"
+    labels:
+      - traefik.http.routers.api.rule=Host(`api.ardiane.local`)
+    restart: on-failure
+
+  database:
+    container_name: ardiane_database
+    image: postgres:13.3
+    environment:
+      POSTGRES_USER: "ardiane"
+      POSTGRES_PASSWORD: "password"
+      POSTGRES_DB: "ardiane"
+    labels:
+      - traefik.enable=false
+    restart: on-failure
+    volumes:
+      - "ardiane-data:/var/lib/postgresql/data"
+
+  traefik:
+    container_name: ardiane_proxy
+    image: traefik:2.4.8
+    labels:
+      - traefik.http.routers.dashboard.rule=Host(`proxy.ardiane.local`)
+      - traefik.http.routers.dashboard.service=api@internal
+    ports:
+      - "80:80"
+    restart: on-failure
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "./traefik/traefik.toml:/traefik.toml"
+
+  pgadmin:
+    container_name: ardiane_pgadmin
+    image: dpage/pgadmin4:5
+    depends_on:
+      - database
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: my-secret-pw 
+    labels:
+      - traefik.http.routers.pgadmin.rule=Host(`pgadmin.ardiane.local`)
+    restart: always
+
+
+volumes:
+  ardiane-data: {}

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -3,7 +3,8 @@ version: "3"
 
 
 services:
-  apiv2:
+
+  api:
     container_name: ardiane_api
     image: ardianethread/ardiane_api
     depends_on:
@@ -24,6 +25,8 @@ services:
       POSTGRES_USER: "ardiane"
       POSTGRES_PASSWORD: "password"
       POSTGRES_DB: "ardiane"
+    labels:
+      - traefik.enable=false
     restart: on-failure
     volumes:
       - "ardiane-data:/var/lib/postgresql/data"
@@ -36,11 +39,22 @@ services:
       - traefik.http.routers.dashboard.service=api@internal
     ports:
       - "80:80"
-      - "8080:8080"
     restart: on-failure
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "./traefik/traefik.toml:/traefik.toml"
+
+  pgadmin:
+    container_name: ardiane_pgadmin
+    image: dpage/pgadmin4:5
+    depends_on:
+      - database
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: my-secret-pw 
+    labels:
+      - traefik.http.routers.pgadmin.rule=Host(`pgadmin.ardiane.com`)
+    restart: always
 
 
 volumes:


### PR DESCRIPTION
Because prod and dev don't use the same configuration, I created 2 distinct `compose` files for each environment.